### PR TITLE
参加者用/発表一覧機能

### DIFF
--- a/src/views/EventDetail.vue
+++ b/src/views/EventDetail.vue
@@ -14,7 +14,7 @@
         </v-card-text>
       </v-card>
 
-      <v-card>
+      <v-card v-if="event.presentations != 0">
 
         <v-list two-line>
           <template v-for="presentation in event.presentations">
@@ -38,7 +38,15 @@
 
           </template>
         </v-list>
+
       </v-card>
+
+      <v-card v-else :indeterminate="event.presentations == 0">
+        <v-card-text>
+          まだ発表はありません。
+        </v-card-text>
+      </v-card>
+
       <v-btn
         fixed
         fab


### PR DESCRIPTION
プレゼンがないときの挙動を追加

プレゼンが0件の場合はメッセージを表示するように変更。

![image](https://user-images.githubusercontent.com/12679843/54034799-27b0b680-41fb-11e9-8f51-910cacee37f2.png)
