### PR TITLE
ページ遷移時にページの先頭が表示されない

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -38,5 +38,12 @@ export default new Router({
       // which is lazy-loaded when the route is visited.
       component: () => import(/* webpackChunkName: "about" */ './views/About.vue')
     }
-  ]
+  ],
+  scrollBehavior (to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition
+    } else {
+      return { x: 0, y: 0 }
+    }
+  }
 })


### PR DESCRIPTION
ページの先頭が表示されるよう修正。
位置が保存されている場合はその場所を表示するように修正。
refs #48 
close #48 