### PR TITLE
不要コードの削除

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,13 +21,6 @@
           </v-list-tile-content>
         </v-list-tile>
         <v-divider></v-divider>
-        <v-list-tile v-for="p in presentations" :key="p.id">
-          <v-list-tile-content>
-            <v-list-tile-title>
-              <router-link :to="{ name: 'presentationDetail', params: { id: p.id }}">{{ p.title }}</router-link>
-            </v-list-tile-title>
-          </v-list-tile-content>
-        </v-list-tile>
       </v-list>
 
       <qriously id="qrcode" class="pb-4" :value="href.here" :size="150"/>


### PR DESCRIPTION
少し前から出力されていたエラーの対応をしました。

原因は、画面遷移がまだ満足にできないときに、メニューにプレゼン一覧を表示していた際のコードが残っていたことによるものです。

今は不要なので、すべて削除しました。

誰か内容を確認し、問題がなければマージお願いします。

![image](https://user-images.githubusercontent.com/12679843/56092708-36754200-5efa-11e9-987d-8c4ca0e32f05.png)
