### PR TITLE
参加者用/FB希望制御

### DIFF
--- a/src/views/PresentationDetail.vue
+++ b/src/views/PresentationDetail.vue
@@ -15,7 +15,7 @@
         </v-card-text>
       </v-card>
 
-      <v-card>
+      <v-card v-if="presentation.isAllowComment">
         <v-card-title>
           <h1 class="headline">コメント一覧</h1>
         </v-card-title>
@@ -51,6 +51,7 @@
       <v-dialog
         v-model="dialog"
         width="500"
+        v-if="presentation.isAllowComment"
       >
         <v-btn
           slot="activator"

--- a/src/views/PresentationDetail.vue
+++ b/src/views/PresentationDetail.vue
@@ -36,6 +36,11 @@
           <p>まだコメントはありません。</p>
         </v-card-text>
       </v-card>
+      <v-card v-else>
+        <v-card-title>
+          <div class="grey--text">この発表にはコメントできません。</div>
+        </v-card-title>
+      </v-card>
 
       <v-btn
         fixed

--- a/src/views/PresentationDetail.vue
+++ b/src/views/PresentationDetail.vue
@@ -15,7 +15,7 @@
         </v-card-text>
       </v-card>
 
-      <v-card v-if="presentation.isAllowComment">
+      <v-card v-if="presentation.isAllowComment !== false">
         <v-card-title>
           <h1 class="headline">コメント一覧</h1>
         </v-card-title>
@@ -56,7 +56,7 @@
       <v-dialog
         v-model="dialog"
         width="500"
-        v-if="presentation.isAllowComment"
+        v-if="presentation.isAllowComment !== false"
       >
         <v-btn
           slot="activator"


### PR DESCRIPTION
プレゼンテーションのフィールドに「コメントを受け付けるか」のフラグを持つことで管理。
プレゼンテーション詳細画面のおいて、コメント一覧と鉛筆ボタンを非表示にしました。