### PR TITLE
サブスクリーンの実装：管理画面

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,16 @@
       <v-divider></v-divider>
 
       <v-list dense class="pt-0">
+        <v-list-tile :to="{name: 'adminScreenList' }">
+          <v-list-tile-action>
+            <v-icon>cast</v-icon>
+          </v-list-tile-action>
+          <v-list-tile-content>
+            <v-list-tile-title>スクリーンの設定</v-list-tile-title>
+          </v-list-tile-content>
+        </v-list-tile>
+        <v-divider></v-divider>
+
         <v-list-tile :href="href.issues">
           <v-list-tile-action>
             <v-icon>feedback</v-icon>

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,7 +39,7 @@
 
         <v-divider></v-divider>
 
-        <v-list-tile v-if="permission && permission.isAdmin" :to="{name: 'adminScreenList' }">
+        <v-list-tile v-if="user && user.isAdmin" :to="{name: 'adminScreenList' }">
           <v-list-tile-action>
             <v-icon>cast</v-icon>
           </v-list-tile-action>
@@ -94,9 +94,6 @@ export default {
     },
     user () {
       return this.$store.getters.user
-    },
-    permission () {
-      return this.$store.getters.permission
     }
   },
   beforeCreate () {

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,17 +39,6 @@
 
         <v-divider></v-divider>
 
-        <v-list-tile v-if="user && user.isAdmin" :to="{name: 'adminScreenList' }">
-          <v-list-tile-action>
-            <v-icon>cast</v-icon>
-          </v-list-tile-action>
-          <v-list-tile-content>
-            <v-list-tile-title>スクリーンの設定</v-list-tile-title>
-          </v-list-tile-content>
-        </v-list-tile>
-
-        <v-divider></v-divider>
-
         <v-list-tile :href="href.issues">
           <v-list-tile-action>
             <v-icon>feedback</v-icon>
@@ -59,6 +48,23 @@
           </v-list-tile-content>
         </v-list-tile>
         <v-divider></v-divider>
+
+        <template v-if="user && user.isAdmin">
+          <v-list-tile>
+            <strong>管理者メニュー</strong>
+          </v-list-tile>
+
+          <v-list-tile :to="{name: 'adminScreenList' }">
+            <v-list-tile-action>
+              <v-icon>cast</v-icon>
+            </v-list-tile-action>
+            <v-list-tile-content>
+              <v-list-tile-title>スクリーンの設定</v-list-tile-title>
+            </v-list-tile-content>
+          </v-list-tile>
+
+          <v-divider></v-divider>
+        </template>
       </v-list>
 
       <qriously id="qrcode" class="pb-4" :value="href.here" :size="150"/>

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,7 +39,7 @@
 
         <v-divider></v-divider>
 
-        <v-list-tile :to="{name: 'adminScreenList' }">
+        <v-list-tile v-if="permission && permission.isAdmin" :to="{name: 'adminScreenList' }">
           <v-list-tile-action>
             <v-icon>cast</v-icon>
           </v-list-tile-action>
@@ -94,6 +94,9 @@ export default {
     },
     user () {
       return this.$store.getters.user
+    },
+    permission () {
+      return this.$store.getters.permission
     }
   },
   beforeCreate () {

--- a/src/main.js
+++ b/src/main.js
@@ -18,10 +18,16 @@ Vue.use(VueQriously)
 Vue.config.productionTip = false
 
 router.beforeEach((to, from, next) => {
-  // 権限による表示制御
   const user = store.getters.user
+  // 権限情報の更新
+  if (user !== null && user.isAdmin) {
+    // ドキュメント読み取り数削減のため、管理者のみ権限を確認する
+    store.dispatch('updatePermission', user.permissionId)
+  }
+  // 権限による表示制御
   if (to.matched.some(record => record.meta.needsAdmin) &&
     (user === null || !user.isAdmin)) {
+    // 権限がない場合
     next({ name: 'error' })
   } else {
     next()

--- a/src/main.js
+++ b/src/main.js
@@ -17,23 +17,6 @@ Vue.use(Vuetify)
 Vue.use(VueQriously)
 Vue.config.productionTip = false
 
-router.beforeEach((to, from, next) => {
-  const user = store.getters.user
-  // 権限情報の更新
-  if (user !== null && user.isAdmin) {
-    // ドキュメント読み取り数削減のため、管理者のみ権限を確認し、必要な場合更新する
-    store.dispatch('updatePermission', user.id)
-  }
-  // 権限による表示制御
-  if (to.matched.some(record => record.meta.needsAdmin) &&
-    (user === null || !user.isAdmin)) {
-    // 権限がない場合
-    next({ name: 'error' })
-  } else {
-    next()
-  }
-})
-
 new Vue({
   router,
   store,

--- a/src/main.js
+++ b/src/main.js
@@ -21,8 +21,8 @@ router.beforeEach((to, from, next) => {
   const user = store.getters.user
   // 権限情報の更新
   if (user !== null && user.isAdmin) {
-    // ドキュメント読み取り数削減のため、管理者のみ権限を確認する
-    store.dispatch('updatePermission', user.permissionId)
+    // ドキュメント読み取り数削減のため、管理者のみ権限を確認し、必要な場合更新する
+    store.dispatch('updatePermission', user.id)
   }
   // 権限による表示制御
   if (to.matched.some(record => record.meta.needsAdmin) &&

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,17 @@ Vue.use(Vuetify)
 Vue.use(VueQriously)
 Vue.config.productionTip = false
 
+router.beforeEach((to, from, next) => {
+  // 権限による表示制御
+  const user = store.getters.user
+  if (to.matched.some(record => record.meta.needsAdmin) &&
+    (user === null || !user.isAdmin)) {
+    next({ name: 'error' })
+  } else {
+    next()
+  }
+})
+
 new Vue({
   router,
   store,

--- a/src/router.js
+++ b/src/router.js
@@ -84,7 +84,10 @@ router.beforeEach((to, from, next) => {
   const user = store.getters.user
   // 権限情報の更新
   if (user !== null && user.isAdmin) {
-    // ドキュメント読み取り数削減のため、管理者のみ権限を確認し、必要な場合更新する
+    // 権限を更新する
+    // 権限の確認を全ての画面遷移時に行うと、ドキュメントの読取りが毎回発生し、
+    // 読取り回数が増加するため、
+    // ここで、管理者権限が必要なページへ遷移するときのみ権限を更新する
     store.dispatch('updatePermission', user.id)
   }
   // 権限による表示制御

--- a/src/router.js
+++ b/src/router.js
@@ -6,6 +6,7 @@ import EventDetail from './views/EventDetail.vue'
 import PresentationDetail from './views/PresentationDetail.vue'
 import AdminScreenSetting from './views/AdminScreenSetting.vue'
 import AdminScreenList from './views/AdminScreenList.vue'
+import Error from './views/Error.vue'
 
 Vue.use(Router)
 
@@ -41,13 +42,24 @@ export default new Router({
     {
       path: '/screens',
       name: 'adminScreenList',
-      component: AdminScreenList
+      component: AdminScreenList,
+      meta: { needsAdmin: true }
     },
     {
       path: '/screens/:id',
       name: 'adminScreenSetting',
       component: AdminScreenSetting,
-      props: true
+      props: true,
+      meta: { needsAdmin: true }
+    },
+    {
+      path: '/error',
+      name: 'error',
+      component: Error
+    },
+    {
+      path: '/*',
+      redirect: '/error'
     }
   ],
   scrollBehavior (to, from, savedPosition) {

--- a/src/router.js
+++ b/src/router.js
@@ -32,9 +32,10 @@ export default new Router({
       props: true
     },
     {
-      path: '/admin/screens',
+      path: '/admin/screens/:id',
       name: 'adminScreenSetting',
-      component: AdminScreenSetting
+      component: AdminScreenSetting,
+      props: true
     }
   ],
   scrollBehavior (to, from, savedPosition) {

--- a/src/router.js
+++ b/src/router.js
@@ -82,18 +82,20 @@ const router = new Router({
  */
 router.beforeEach((to, from, next) => {
   const user = store.getters.user
-  // 権限情報の更新
   if (user !== null && user.isAdmin) {
     // 権限を更新する
-    // 権限の確認を全ての画面遷移時に行うと、ドキュメントの読取りが毎回発生し、
+    // 裏で管理者権限が剥奪されている可能性があるため、
+    // ページ遷移時に権限を更新する必要があるが、
+    // 全ての画面遷移時に更新を行うと、ドキュメントの読取りが毎回発生し、
     // 読取り回数が増加するため、
-    // ここで、管理者権限が必要なページへ遷移するときのみ権限を更新する
+    // ここで、管理者権限が必要なページへ遷移するときのみ権限を更新する。
     store.dispatch('updatePermission', user.id)
   }
+
   // 権限による表示制御
   if (to.matched.some(record => record.meta.needsAdmin) &&
     (user === null || !user.isAdmin)) {
-    // 権限がない場合
+    // 権限がない場合はエラーページへ遷移
     next({ name: 'error' })
   } else {
     next()

--- a/src/router.js
+++ b/src/router.js
@@ -33,12 +33,12 @@ export default new Router({
       props: true
     },
     {
-      path: '/admin/screens',
+      path: '/screens',
       name: 'adminScreenList',
       component: AdminScreenList
     },
     {
-      path: '/admin/screens/:id',
+      path: '/screens/:id',
       name: 'adminScreenSetting',
       component: AdminScreenSetting,
       props: true

--- a/src/router.js
+++ b/src/router.js
@@ -3,6 +3,7 @@ import Router from 'vue-router'
 import EventList from './views/EventList.vue'
 import EventDetail from './views/EventDetail.vue'
 import PresentationDetail from './views/PresentationDetail.vue'
+import AdminScreenSetting from './views/AdminScreenSetting.vue'
 
 Vue.use(Router)
 
@@ -31,12 +32,9 @@ export default new Router({
       props: true
     },
     {
-      path: '/about',
-      name: 'about',
-      // route level code-splitting
-      // this generates a separate chunk (about.[hash].js) for this route
-      // which is lazy-loaded when the route is visited.
-      component: () => import(/* webpackChunkName: "about" */ './views/About.vue')
+      path: '/screens',
+      name: 'adminScreenSetting',
+      component: AdminScreenSetting
     }
   ],
   scrollBehavior (to, from, savedPosition) {

--- a/src/router.js
+++ b/src/router.js
@@ -4,6 +4,7 @@ import EventList from './views/EventList.vue'
 import EventDetail from './views/EventDetail.vue'
 import PresentationDetail from './views/PresentationDetail.vue'
 import AdminScreenSetting from './views/AdminScreenSetting.vue'
+import AdminScreenList from './views/AdminScreenList.vue'
 
 Vue.use(Router)
 
@@ -30,6 +31,11 @@ export default new Router({
       name: 'presentationDetail',
       component: PresentationDetail,
       props: true
+    },
+    {
+      path: '/admin/screens',
+      name: 'adminScreenList',
+      component: AdminScreenList
     },
     {
       path: '/admin/screens/:id',

--- a/src/router.js
+++ b/src/router.js
@@ -32,7 +32,7 @@ export default new Router({
       props: true
     },
     {
-      path: '/screens',
+      path: '/admin/screens',
       name: 'adminScreenSetting',
       component: AdminScreenSetting
     }

--- a/src/store.js
+++ b/src/store.js
@@ -104,7 +104,7 @@ export default new Vuex.Store({
       bindFirebaseRef('comments', comments)
       bindFirebaseRef('screens', screens)
     }),
-    login ({ commit, getters }, auth) {
+    login ({ commit }, auth) {
       const userDoc = users.doc(auth.uid)
       userDoc
         .get()

--- a/src/store.js
+++ b/src/store.js
@@ -172,12 +172,19 @@ export default new Vuex.Store({
       })
     },
     /*
-     * screenドキュメントを更新する
+     * screenドキュメントの表示中プレゼンテーションを更新する
      */
     updateScreen ({ state }, { screenId, presentationId }) {
-      // TODO get screenInfo
       screens.doc(screenId).update({
         displayPresentationRef: presentations.doc(presentationId)
+      })
+    },
+    /*
+     * screenドキュメントの表示中プレゼンテーションを削除する
+     */
+    unsetScreenPresentation ({ state }, screenId) {
+      screens.doc(screenId).update({
+        displayPresentationRef: null
       })
     }
   }

--- a/src/store.js
+++ b/src/store.js
@@ -140,6 +140,12 @@ export default new Vuex.Store({
      * screenドキュメントを更新する
      */
     updateScreen ({ state }, screenInfo) {
+      if (screenInfo.displayPresentationRef) {
+        // 参照値を取得してから更新
+        screenInfo.displayPresentationRef = presentations.doc(screenInfo.displayPresentationRef.id)
+      } else {
+        screenInfo.displayPresentationRef = null
+      }
       screens.doc(screenInfo.id).set(screenInfo)
     }
   }

--- a/src/store.js
+++ b/src/store.js
@@ -135,6 +135,9 @@ export default new Vuex.Store({
         presentationId,
         userRef: users.doc(state.user.id)
       })
+    },
+    updateScreen ({ state }, screenInfo) {
+      console.log(screenInfo)
     }
   }
 })

--- a/src/store.js
+++ b/src/store.js
@@ -94,12 +94,6 @@ export default new Vuex.Store({
     setUser (state, payload) {
       state.user = payload
     },
-    /*
-     * userオブジェクトにisAdminフラグをセットする
-     */
-    setAdminPermission (state, payload) {
-      state.user.isAdmin = payload
-    },
     ...firebaseMutations
   },
   actions: {
@@ -117,20 +111,18 @@ export default new Vuex.Store({
         .then((authUserInfo) => {
           if (authUserInfo.exists) {
             // 登録済みユーザの場合
-            commit('setUser', {
-              id: authUserInfo.id,
-              name: authUserInfo.data().name,
-              photoURL: authUserInfo.data().photoURL,
-              isAdmin: false
-            })
             // 権限情報の取得
             permissions
               .where('userId', '==', authUserInfo.id)
               .get()
               .then(function (querySnapshot) {
-                if (!querySnapshot.empty) {
-                  commit('setAdminPermission', querySnapshot.docs[0].data().isAdmin)
-                }
+                const isAdmin = !querySnapshot.empty ? querySnapshot.docs[0].data().isAdmin : false
+                commit('setUser', {
+                  id: authUserInfo.id,
+                  name: authUserInfo.data().name,
+                  photoURL: authUserInfo.data().photoURL,
+                  isAdmin: isAdmin
+                })
               })
           } else {
             // 未登録ユーザの場合

--- a/src/store.js
+++ b/src/store.js
@@ -151,7 +151,7 @@ export default new Vuex.Store({
     },
     logout ({ commit }) {
       commit('setUser', null)
-      commit('permission', null)
+      commit('setPermission', null)
     },
     appendComment ({ state }, { comment, presentationId }) {
       comments.add({

--- a/src/store.js
+++ b/src/store.js
@@ -116,13 +116,24 @@ export default new Vuex.Store({
         .get()
         .then((authUserInfo) => {
           if (authUserInfo.exists) {
+            // 登録済みユーザの場合
             commit('setUser', {
               id: authUserInfo.id,
               name: authUserInfo.data().name,
               photoURL: authUserInfo.data().photoURL,
               isAdmin: false
             })
+            // 権限情報の取得
+            permissions
+              .where('userId', '==', authUserInfo.id)
+              .get()
+              .then(function (querySnapshot) {
+                if (!querySnapshot.empty) {
+                  commit('setAdminPermission', querySnapshot.docs[0].data().isAdmin)
+                }
+              })
           } else {
+            // 未登録ユーザの場合
             userDoc
               .set({
                 name: auth.displayName,
@@ -134,19 +145,6 @@ export default new Vuex.Store({
               photoURL: auth.photoURL,
               isAdmin: false
             })
-          }
-          // 権限情報取得
-          const userInfo = getters.user
-          // ユーザ情報取得済みの場合
-          if (userInfo !== null) {
-            permissions
-              .where('userId', '==', auth.uid)
-              .get()
-              .then(function (querySnapshot) {
-                if (!querySnapshot.empty) {
-                  commit('setAdminPermission', querySnapshot.docs[0].data().isAdmin)
-                }
-              })
           }
         }).catch((error) => {
           console.log('Error getting document:', error)

--- a/src/store.js
+++ b/src/store.js
@@ -94,6 +94,9 @@ export default new Vuex.Store({
     setUser (state, payload) {
       state.user = payload
     },
+    setUserIsAdmin (state, payload) {
+      state.user.isAdmin = payload
+    },
     ...firebaseMutations
   },
   actions: {
@@ -117,11 +120,13 @@ export default new Vuex.Store({
               .get()
               .then(function (querySnapshot) {
                 const isAdmin = !querySnapshot.empty ? querySnapshot.docs[0].data().isAdmin : false
+                const permissionId = !querySnapshot.empty ? querySnapshot.docs[0].id : null
                 commit('setUser', {
                   id: authUserInfo.id,
                   name: authUserInfo.data().name,
                   photoURL: authUserInfo.data().photoURL,
-                  isAdmin: isAdmin
+                  isAdmin: isAdmin,
+                  permissionId: permissionId
                 })
               })
           } else {
@@ -144,6 +149,21 @@ export default new Vuex.Store({
     },
     logout ({ commit }) {
       commit('setUser', null)
+    },
+    /*
+     * ユーザの権限情報を更新する
+     */
+    updatePermission ({ commit }, permissionId) {
+      const permissionDoc = permissions.doc(permissionId)
+      permissionDoc
+        .get()
+        .then((permission) => {
+          if (permission.exists) {
+            commit('setUserIsAdmin', permission.data().isAdmin)
+          } else {
+            commit('setUserIsAdmin', false)
+          }
+        })
     },
     appendComment ({ state }, { comment, presentationId }) {
       comments.add({

--- a/src/store.js
+++ b/src/store.js
@@ -136,8 +136,11 @@ export default new Vuex.Store({
         userRef: users.doc(state.user.id)
       })
     },
+    /*
+     * screenドキュメントを更新する
+     */
     updateScreen ({ state }, screenInfo) {
-      console.log(screenInfo)
+      screens.doc(screenInfo.id).set(screenInfo)
     }
   }
 })

--- a/src/store.js
+++ b/src/store.js
@@ -176,8 +176,11 @@ export default new Vuex.Store({
     /*
      * screenドキュメントを更新する
      */
-    updateScreen ({ state }, screenInfo) {
-      screens.doc(screenInfo.id).set(screenInfo)
+    updateScreen ({ state }, { screenId, presentationId }) {
+      // TODO get screenInfo
+      screens.doc(screenId).update({
+        displayPresentationRef: presentations.doc(presentationId)
+      })
     }
   }
 })

--- a/src/store.js
+++ b/src/store.js
@@ -174,7 +174,7 @@ export default new Vuex.Store({
     /*
      * screenドキュメントの表示中プレゼンテーションを更新する
      */
-    updateScreen ({ state }, { screenId, presentationId }) {
+    updateScreenPresentation ({ state }, { screenId, presentationId }) {
       screens.doc(screenId).update({
         displayPresentationRef: presentations.doc(presentationId)
       })

--- a/src/store.js
+++ b/src/store.js
@@ -94,6 +94,12 @@ export default new Vuex.Store({
     setUser (state, payload) {
       state.user = payload
     },
+    /*
+     * userオブジェクトにisAdminフラグをセットする
+     */
+    setAdminPermission (state, payload) {
+      state.user.isAdmin = payload
+    },
     ...firebaseMutations
   },
   actions: {
@@ -130,20 +136,18 @@ export default new Vuex.Store({
             })
           }
           // 権限情報取得
-          permissions
-            .where('userId', '==', auth.uid)
-            .get()
-            .then(function (querySnapshot) {
-              if (!querySnapshot.empty) {
-                const userInfo = getters.user
-                commit('setUser', {
-                  id: userInfo.id,
-                  name: userInfo.name,
-                  photoURL: userInfo.photoURL,
-                  isAdmin: querySnapshot.docs[0].data().isAdmin
-                })
-              }
-            })
+          const userInfo = getters.user
+          // ユーザ情報取得済みの場合
+          if (userInfo !== null) {
+            permissions
+              .where('userId', '==', auth.uid)
+              .get()
+              .then(function (querySnapshot) {
+                if (!querySnapshot.empty) {
+                  commit('setAdminPermission', querySnapshot.docs[0].data().isAdmin)
+                }
+              })
+          }
         }).catch((error) => {
           console.log('Error getting document:', error)
         })

--- a/src/store.js
+++ b/src/store.js
@@ -13,6 +13,7 @@ const users = firestore.collection('users')
 const events = firestore.collection('events')
 const presentations = firestore.collection('presentations')
 const comments = firestore.collection('comments')
+const screens = firestore.collection('screens')
 
 Vue.use(Vuex)
 
@@ -22,7 +23,8 @@ export default new Vuex.Store({
     user: null,
     events: [],
     presentations: [],
-    comments: []
+    comments: [],
+    screens: []
   },
   getters: {
     events (state, getters) {
@@ -62,6 +64,9 @@ export default new Vuex.Store({
           return dsec === 0 ? (dnanosec > 0) - (dnanosec < 0) : (dsec > 0) - (dsec < 0)
         })
     },
+    screens (state) {
+      return state.screens
+    },
     event (state, getters) {
       return (id) => getters.events.find((e) => e.id === id)
     },
@@ -70,6 +75,9 @@ export default new Vuex.Store({
     },
     comment (state, getters) {
       return (id) => getters.comments.find((e) => e.id === id)
+    },
+    screen (state, getters) {
+      return (id) => getters.screens.find((e) => e.id === id)
     }
   },
   mutations: {
@@ -83,6 +91,7 @@ export default new Vuex.Store({
       bindFirebaseRef('events', events)
       bindFirebaseRef('presentations', presentations)
       bindFirebaseRef('comments', comments)
+      bindFirebaseRef('screens', screens)
     }),
     setUser ({ commit }, auth) {
       const userDoc = users.doc(auth.uid)

--- a/src/store.js
+++ b/src/store.js
@@ -82,12 +82,6 @@ export default new Vuex.Store({
     },
     screen (state, getters) {
       return (id) => getters.screens.find((e) => e.id === id)
-    },
-    /*
-     * Presentationドキュメントの参照値を返す
-     */
-    presentationRef (state, getters) {
-      return (id) => presentations.doc(id)
     }
   },
   mutations: {

--- a/src/store.js
+++ b/src/store.js
@@ -116,17 +116,15 @@ export default new Vuex.Store({
             // 登録済みユーザの場合
             // 権限情報の取得
             permissions
-              .where('userId', '==', authUserInfo.id)
+              .doc(authUserInfo.id)
               .get()
-              .then(function (querySnapshot) {
-                const isAdmin = !querySnapshot.empty ? querySnapshot.docs[0].data().isAdmin : false
-                const permissionId = !querySnapshot.empty ? querySnapshot.docs[0].id : null
+              .then(function (permissionInfo) {
+                const isAdmin = permissionInfo.exists ? permissionInfo.data().isAdmin : false
                 commit('setUser', {
                   id: authUserInfo.id,
                   name: authUserInfo.data().name,
                   photoURL: authUserInfo.data().photoURL,
-                  isAdmin: isAdmin,
-                  permissionId: permissionId
+                  isAdmin: isAdmin
                 })
               })
           } else {
@@ -153,8 +151,8 @@ export default new Vuex.Store({
     /*
      * ユーザの権限情報を更新する
      */
-    updatePermission ({ commit }, permissionId) {
-      const permissionDoc = permissions.doc(permissionId)
+    updatePermission ({ commit }, userId) {
+      const permissionDoc = permissions.doc(userId)
       permissionDoc
         .get()
         .then((permission) => {

--- a/src/store.js
+++ b/src/store.js
@@ -82,6 +82,12 @@ export default new Vuex.Store({
     },
     screen (state, getters) {
       return (id) => getters.screens.find((e) => e.id === id)
+    },
+    /*
+     * Presentationドキュメントの参照値を返す
+     */
+    presentationRef (state, getters) {
+      return (id) => presentations.doc(id)
     }
   },
   mutations: {
@@ -140,12 +146,6 @@ export default new Vuex.Store({
      * screenドキュメントを更新する
      */
     updateScreen ({ state }, screenInfo) {
-      if (screenInfo.displayPresentationRef) {
-        // 参照値を取得してから更新
-        screenInfo.displayPresentationRef = presentations.doc(screenInfo.displayPresentationRef.id)
-      } else {
-        screenInfo.displayPresentationRef = null
-      }
       screens.doc(screenInfo.id).set(screenInfo)
     }
   }

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -1,5 +1,0 @@
-<template>
-  <div class="about">
-    <h1>This is an about page</h1>
-  </div>
-</template>

--- a/src/views/AdminScreenList.vue
+++ b/src/views/AdminScreenList.vue
@@ -12,7 +12,7 @@
       <v-card v-if="screens">
         <v-list>
 
-          <template v-for="screen in screens">
+          <template v-for="(screen, index) in screens">
             <v-list-tile
               :to="{ path: 'screens/' + screen.id }"
               :key="screen.id + '_list'">
@@ -25,7 +25,11 @@
                 </template>
               </v-list-tile-title>
             </v-list-tile>
-            <v-divider :key="screen.id + '_divider'" class="mx-2 my-2"></v-divider>
+            <v-divider
+              v-if="index+1 < screens.length"
+              :key="screen.id + '_divider'"
+              class="mx-2 my-2">
+            </v-divider>
           </template>
 
         </v-list>

--- a/src/views/AdminScreenList.vue
+++ b/src/views/AdminScreenList.vue
@@ -1,0 +1,49 @@
+<template>
+  <v-layout row class="pb-5">
+    <v-flex>
+      <v-card>
+        <v-card-title>
+          <div>
+            <h3 class="headline mb-0">スクリーン管理</h3>
+          </div>
+        </v-card-title>
+      </v-card>
+
+      <v-card v-if="screens">
+        <v-list>
+
+          <template v-for="screen in screens">
+            <v-list-tile
+              :to="{ path: screen.id }"
+              :key="screen.id + '_list'">
+              <v-list-tile-title class="title ml-2" :key="screen.id + '_title'">
+                {{ screen.name }}
+              </v-list-tile-title>
+            </v-list-tile>
+            <v-divider :key="screen.id + '_divider'" class="mx-2 my-2"></v-divider>
+          </template>
+
+        </v-list>
+      </v-card>
+
+      <v-card v-else>
+        <v-card-title>
+          <div>
+            スクリーンが登録されていません。
+          </div>
+        </v-card-title>
+      </v-card>
+
+    </v-flex>
+  </v-layout>
+</template>
+<script>
+export default {
+  name: 'adminScreenList',
+  computed: {
+    screens () {
+      return this.$store.getters.screens
+    }
+  }
+}
+</script>

--- a/src/views/AdminScreenList.vue
+++ b/src/views/AdminScreenList.vue
@@ -14,7 +14,7 @@
 
           <template v-for="screen in screens">
             <v-list-tile
-              :to="{ path: screen.id }"
+              :to="{ path: 'screens/' + screen.id }"
               :key="screen.id + '_list'">
               <v-list-tile-title class="title ml-2" :key="screen.id + '_title'">
                 {{ screen.name }}

--- a/src/views/AdminScreenList.vue
+++ b/src/views/AdminScreenList.vue
@@ -17,7 +17,12 @@
               :to="{ path: 'screens/' + screen.id }"
               :key="screen.id + '_list'">
               <v-list-tile-title class="title ml-2" :key="screen.id + '_title'">
-                {{ screen.name }}
+                <template v-if="screen.name">
+                  {{ screen.name }}
+                </template>
+                <template v-else>
+                  （スクリーン名未設定）
+                </template>
               </v-list-tile-title>
             </v-list-tile>
             <v-divider :key="screen.id + '_divider'" class="mx-2 my-2"></v-divider>

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -75,7 +75,7 @@
       <v-card v-if="this.selectedEvent">
         <v-list two-line>
 
-          <template v-for="presentation in selectedEvent.presentations">
+          <template v-for="(presentation, index) in selectedEvent.presentations">
             <v-list-tile
               v-if="presentation.id"
               @click="selectPresentation(presentation)"
@@ -93,8 +93,8 @@
                   cast
                 </v-icon>
               </v-list-tile-avatar>
-              <v-list-tile-content class="ml-2">
-                <v-list-tile-title class="title" :key="presentation.id + '_title'">
+              <v-list-tile-content>
+                <v-list-tile-title :key="presentation.id + '_title'">
                   {{ presentation.title }}
                 </v-list-tile-title>
                 <v-list-tile-sub-title v-if="presentation.presenter" :key="presentation.id + '_subtitle'">
@@ -102,7 +102,12 @@
                 </v-list-tile-sub-title>
               </v-list-tile-content>
             </v-list-tile>
-            <v-divider :key="presentation.id + '_divider'" class="mx-2 my-2"></v-divider>
+            <v-divider
+              v-if="index+1 < selectedEvent.presentations.length"
+              :key="presentation.id + '_divider'"
+              class="mx-2 my-2"
+            >
+            </v-divider>
           </template>
 
           <template v-if="selectedEvent.presentations == 0">

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -193,10 +193,7 @@ export default {
      */
     initializeScreen () {
       if (confirm('スクリーンの表示をリセットします。よろしいですか？')) {
-        this.$store.dispatch('updateScreen', {
-          screenId: this.id,
-          presentationId: null
-        })
+        this.$store.dispatch('unsetScreenPresentation', this.id)
       }
     }
   }

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -160,7 +160,7 @@ export default {
         '」の情報に変更します。\n' +
         'よろしいですか？'
       if (confirm(msg)) {
-        const targetPresentationRef = this.$store.getters.presentation(targetPresentation.id)
+        const targetPresentationRef = this.$store.getters.presentationRef(targetPresentation.id)
         this.$store.dispatch('updateScreen', {
           id: this.id,
           displayPresentationRef: targetPresentationRef

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -3,9 +3,16 @@
     <v-flex>
 
       <v-card class="mb-2">
+
         <v-card-title>
-          <h1 class="headline">スクリーン管理</h1>
+          <div>
+            <div v-if="screen" class="grey--text">
+              {{ screen.name }}
+            </div>
+            <h3 class="headline mb-0">スクリーン管理</h3>
+          </div>
         </v-card-title>
+
         <v-container grid-list-md class="py-0">
           <v-layout row wrap>
 
@@ -27,31 +34,41 @@
 
       <v-card v-if="this.event">
         <v-list two-line>
+
           <template v-for="presentation in event.presentations">
-            <v-list-tile v-if="presentation.id" :key="presentation.id + '_list'" class="my-2">
-
+            <v-list-tile
+              v-if="presentation.id"
+              @click="selectPresentation"
+              :key="presentation.id + '_list'"
+              class="my-2">
               <v-list-item-avatar :key="presentation.id + '_avatar'">
-                <v-icon x-large color="grey lighten-1">cast</v-icon>
+                <v-icon v-if="presentation.id == screen.displayPresentationId"
+                  x-large
+                  color="orange lighten-1">
+                  cast_connected
+                </v-icon>
+                <v-icon v-else
+                  x-large
+                  color="grey lighten-1">
+                  cast
+                </v-icon>
               </v-list-item-avatar>
-
               <v-list-tile-title class="title ml-2" :key="presentation.id + '_title'">
                 {{ presentation.title }}
               </v-list-tile-title>
-
               <v-list-tile-sub-title v-if="presentation.presenter" :key="presentation.id + '_subtitle'">
                 by {{ presentation.presenter.name }}
               </v-list-tile-sub-title>
-
             </v-list-tile>
-
             <v-divider :key="presentation.id + '_divider'" class="mx-2 my-2"></v-divider>
-
           </template>
+
           <template v-if="event.presentations == 0">
             <v-card-text>
               まだ発表はありません。
             </v-card-text>
           </template>
+
         </v-list>
       </v-card>
 
@@ -61,6 +78,12 @@
 <script>
 export default {
   name: 'adminScreenSetting',
+  props: {
+    id: {
+      type: String,
+      required: true
+    }
+  },
   data () {
     return {
       selectedEventId: null,
@@ -68,6 +91,9 @@ export default {
     }
   },
   computed: {
+    screen () {
+      return this.$store.getters.screen(this.id)
+    },
     events () {
       return this.$store.getters.events
     },
@@ -81,8 +107,10 @@ export default {
         this.event = {}
       } else {
         this.event = this.$store.getters.event(eventId)
-        console.log(this.event)
       }
+    },
+    selectPresentation () {
+      // TODO:表示中の発表をアップデート
     }
   }
 }

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -109,6 +109,17 @@
         </v-list>
       </v-card>
 
+      <v-btn
+        fixed
+        fab
+        bottom
+        left
+        color="green"
+        :to="{ path: '/screens' }"
+      >
+        <v-icon>arrow_back</v-icon>
+      </v-btn>
+
     </v-flex>
   </v-layout>
 </template>

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -7,7 +7,12 @@
         <v-card-title>
           <div>
             <div v-if="screen" class="grey--text">
-              {{ screen.name }}
+              <template v-if="screen.name">
+                {{ screen.name }}
+              </template>
+              <template v-else>
+                （スクリーン名未設定）
+              </template>
             </div>
             <h3 class="headline mb-0">スクリーンの管理</h3>
           </div>

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -1,0 +1,82 @@
+<template>
+  <v-layout row class="pb-5">
+    <v-flex>
+
+      <v-card class="mb-2">
+        <v-card-title>
+          <h1 class="headline">スクリーン管理</h1>
+        </v-card-title>
+        <v-container grid-list-md class="py-0">
+          <v-layout row wrap>
+
+            <v-flex xs12 sm8>
+              <v-select
+              :items="events"
+              name="event"
+              item-text="title"
+              item-value="id"
+              box
+              label="イベントを選択してください"
+              @change="setEventsPresentations"
+              >
+            </v-select>
+            </v-flex>
+          </v-layout>
+        </v-container>
+      </v-card>
+
+      <v-card>
+        <v-list two-line>
+          <template v-for="presentation in event.presentations">
+            <v-list-tile v-if="presentation.id" :key="'list-' + presentation.id" class="my-2">
+
+              <v-list-item-avatar :key="'avatar-' + presentation.id">
+                <v-icon x-large color="grey lighten-1">cast</v-icon>
+              </v-list-item-avatar>
+
+              <v-list-tile-title class="title ml-2" :key="'title-' + presentation.id">
+                {{ presentation.title }}
+              </v-list-tile-title>
+
+              <v-list-tile-sub-title v-if="presentation.presenter" :key="'sub-title-' + presentation.id">
+                by {{ presentation.presenter.name }}
+              </v-list-tile-sub-title>
+
+              <v-divider :key="'divider-' + presentation.id" class="mx-2"></v-divider>
+            </v-list-tile>
+          </template>
+        </v-list>
+      </v-card>
+
+    </v-flex>
+  </v-layout>
+</template>
+<script>
+export default {
+  name: 'adminScreenSetting',
+  data () {
+    return {
+      selectedEventId: null,
+      event: {}
+    }
+  },
+  computed: {
+    events () {
+      return this.$store.getters.events
+    },
+    selectedEvent () {
+      return this.event
+    }
+  },
+  methods: {
+    setEventsPresentations (eventId) {
+      if (!eventId) {
+        this.event = {}
+      } else {
+        this.event = this.$store.getters.event(eventId)
+        console.log(this.event)
+      }
+    }
+  }
+}
+</script>

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -155,11 +155,9 @@ export default {
         '」の情報に変更します。\n' +
         'よろしいですか？'
       if (confirm(msg)) {
-        const screenInfo = this.$store.getters.screen(this.id)
         this.$store.dispatch('updateScreen', {
-          screenId: this.id,
-          name: targetPresentation.name,
-          displayPresentationRef: targetPresentation.id
+          id: this.id,
+          displayPresentationRef: targetPresentation
         })
       }
     },

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -171,9 +171,11 @@ export default {
         '」の情報に変更します。\n' +
         'よろしいですか？'
       if (confirm(msg)) {
+        const screenInfo = this.$store.getters.screen(this.id)
         const targetPresentationRef = this.$store.getters.presentationRef(targetPresentation.id)
         this.$store.dispatch('updateScreen', {
           id: this.id,
+          name: screenInfo.name,
           displayPresentationRef: targetPresentationRef
         })
       }

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -32,11 +32,11 @@
           <v-layout row wrap>
             <v-flex xs12 sm9 xl11>
 
-              <template v-if="screen && screen.displayPresentationRef">
-                <v-card-title class="px-0 py-0" >
-                  <div>
-                    <strong>表示中の発表：</strong>
-                  </div>
+              <v-card-title class="px-0 py-0" >
+                <div>
+                  <strong>表示中の発表：</strong>
+                </div>
+                <template v-if="screen && screen.displayPresentationRef">
                   <div class="text-truncate">
                     {{ getEventTitle(screen.displayPresentationRef.eventId) }}
                   </div>
@@ -46,8 +46,13 @@
                   <div v-if="screen.displayPresentationRef.presenter" class="text-truncate">
                     &nbsp;（{{ screen.displayPresentationRef.presenter.name }}）
                   </div>
-                </v-card-title>
-              </template>
+                </template>
+                <template v-else>
+                  <div>
+                    なし
+                  </div>
+                </template>
+              </v-card-title>
             </v-flex>
           </v-layout>
           <v-layout row wrap>
@@ -72,7 +77,7 @@
               :key="presentation.id + '_list'"
               class="my-2">
               <v-list-tile-avatar :key="presentation.id + '_avatar'">
-                <v-icon v-if="presentation.id == screen.displayPresentationRef.id"
+                <v-icon v-if="screen.displayPresentationRef && presentation.id == screen.displayPresentationRef.id"
                   x-large
                   color="orange lighten-1">
                   cast_connected
@@ -155,9 +160,10 @@ export default {
         '」の情報に変更します。\n' +
         'よろしいですか？'
       if (confirm(msg)) {
+        const targetPresentationRef = this.$store.getters.presentation(targetPresentation.id)
         this.$store.dispatch('updateScreen', {
           id: this.id,
-          displayPresentationRef: targetPresentation
+          displayPresentationRef: targetPresentationRef
         })
       }
     },
@@ -177,7 +183,10 @@ export default {
      */
     initializeScreen () {
       if (confirm('スクリーンの表示をリセットします。よろしいですか？')) {
-        // TODO:スクリーンを初期化する処理を入れる
+        this.$store.dispatch('updateScreen', {
+          id: this.id,
+          displayPresentationRef: null
+        })
       }
     }
   }

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -122,14 +122,23 @@ export default {
     }
   },
   computed: {
+    /*
+     * スクリーン情報取得
+     */
     screen () {
       return this.$store.getters.screen(this.id)
     },
+    /*
+     * イベント情報取得
+     */
     events () {
       return this.$store.getters.events
     }
   },
   methods: {
+    /*
+     * プレゼンを表示するイベントをセットする
+     */
     setEventsPresentations (eventId) {
       if (!eventId) {
         this.selectedEvent = {}
@@ -137,15 +146,21 @@ export default {
         this.selectedEvent = this.$store.getters.event(eventId)
       }
     },
-    selectPresentation (presentation) {
+    /*
+     * スクリーンに表示するプレゼンをセット
+     */
+    selectPresentation (targetPresentation) {
       const msg = 'スクリーンの表示を「' +
-        presentation.title +
+        targetPresentation.title +
         '」の情報に変更します。\n' +
         'よろしいですか？'
       if (confirm(msg)) {
         // TODO:表示中の発表をアップデート
       }
     },
+    /*
+     * イベント名を取得
+     */
     getEventTitle (eventId) {
       const targetEvent = this.$store.getters.event(eventId)
       if (targetEvent) {
@@ -154,6 +169,9 @@ export default {
         return ''
       }
     },
+    /*
+     * スクリーンを初期化する
+     */
     initializeScreen () {
       if (confirm('スクリーンの表示をリセットします。よろしいですか？')) {
         // TODO:スクリーンを初期化する処理を入れる

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -194,8 +194,10 @@ export default {
      */
     initializeScreen () {
       if (confirm('スクリーンの表示をリセットします。よろしいですか？')) {
+        const screenInfo = this.$store.getters.screen(this.id)
         this.$store.dispatch('updateScreen', {
-          id: this.id,
+          id: screenInfo.id,
+          name: screenInfo.name,
           displayPresentationRef: null
         })
       }

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -171,12 +171,9 @@ export default {
         '」の情報に変更します。\n' +
         'よろしいですか？'
       if (confirm(msg)) {
-        const screenInfo = this.$store.getters.screen(this.id)
-        const targetPresentationRef = this.$store.getters.presentationRef(targetPresentation.id)
         this.$store.dispatch('updateScreen', {
-          id: this.id,
-          name: screenInfo.name,
-          displayPresentationRef: targetPresentationRef
+          screenId: this.id,
+          presentationId: targetPresentation.id
         })
       }
     },
@@ -196,11 +193,9 @@ export default {
      */
     initializeScreen () {
       if (confirm('スクリーンの表示をリセットします。よろしいですか？')) {
-        const screenInfo = this.$store.getters.screen(this.id)
         this.$store.dispatch('updateScreen', {
-          id: screenInfo.id,
-          name: screenInfo.name,
-          displayPresentationRef: null
+          screenId: this.id,
+          presentationId: null
         })
       }
     }

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -25,25 +25,32 @@
         </v-container>
       </v-card>
 
-      <v-card>
+      <v-card v-if="this.event">
         <v-list two-line>
           <template v-for="presentation in event.presentations">
-            <v-list-tile v-if="presentation.id" :key="'list-' + presentation.id" class="my-2">
+            <v-list-tile v-if="presentation.id" :key="presentation.id + '_list'" class="my-2">
 
-              <v-list-item-avatar :key="'avatar-' + presentation.id">
+              <v-list-item-avatar :key="presentation.id + '_avatar'">
                 <v-icon x-large color="grey lighten-1">cast</v-icon>
               </v-list-item-avatar>
 
-              <v-list-tile-title class="title ml-2" :key="'title-' + presentation.id">
+              <v-list-tile-title class="title ml-2" :key="presentation.id + '_title'">
                 {{ presentation.title }}
               </v-list-tile-title>
 
-              <v-list-tile-sub-title v-if="presentation.presenter" :key="'sub-title-' + presentation.id">
+              <v-list-tile-sub-title v-if="presentation.presenter" :key="presentation.id + '_subtitle'">
                 by {{ presentation.presenter.name }}
               </v-list-tile-sub-title>
 
-              <v-divider :key="'divider-' + presentation.id" class="mx-2"></v-divider>
             </v-list-tile>
+
+            <v-divider :key="presentation.id + '_divider'" class="mx-2 my-2"></v-divider>
+
+          </template>
+          <template v-if="event.presentations == 0">
+            <v-card-text>
+              まだ発表はありません。
+            </v-card-text>
           </template>
         </v-list>
       </v-card>
@@ -57,7 +64,7 @@ export default {
   data () {
     return {
       selectedEventId: null,
-      event: {}
+      event: null
     }
   },
   computed: {

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -41,7 +41,7 @@
               @click="selectPresentation"
               :key="presentation.id + '_list'"
               class="my-2">
-              <v-list-item-avatar :key="presentation.id + '_avatar'">
+              <v-list-tile-avatar :key="presentation.id + '_avatar'">
                 <v-icon v-if="presentation.id == screen.displayPresentationId"
                   x-large
                   color="orange lighten-1">
@@ -52,7 +52,7 @@
                   color="grey lighten-1">
                   cast
                 </v-icon>
-              </v-list-item-avatar>
+              </v-list-tile-avatar>
               <v-list-tile-content class="ml-2">
                 <v-list-tile-title class="title" :key="presentation.id + '_title'">
                   {{ presentation.title }}

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -2,7 +2,7 @@
   <v-layout row class="pb-5">
     <v-flex>
 
-      <v-card class="mb-2">
+      <v-card class="mb-2 pb-2">
 
         <v-card-title>
           <div>
@@ -15,7 +15,6 @@
 
         <v-container grid-list-md class="py-0">
           <v-layout row wrap>
-
             <v-flex xs12 sm8>
               <v-select
               :items="events"
@@ -29,20 +28,53 @@
             </v-select>
             </v-flex>
           </v-layout>
+
+          <v-layout row wrap>
+            <v-flex xs12 sm3 xl1>
+              <v-card-title class="px-0 py-0">
+                <strong>表示中の発表：</strong>
+              </v-card-title>
+            </v-flex>
+            <v-flex xs12 sm9 xl11>
+
+              <template v-if="screen && screen.displayPresentationRef">
+                <v-card-title class="px-0 py-0" >
+                  <div class="text-truncate">
+                    {{ getEventTitle(screen.displayPresentationRef.eventId) }}
+                  </div>
+                  <div v-if="screen.displayPresentationRef" class="text-truncate">
+                    &nbsp;>&nbsp;{{ screen.displayPresentationRef.title }}
+                  </div>
+                  <div v-if="screen.displayPresentationRef.presenter" class="text-truncate">
+                    &nbsp;（{{ screen.displayPresentationRef.presenter.name }}）
+                  </div>
+                </v-card-title>
+              </template>
+            </v-flex>
+          </v-layout>
+          <v-layout row wrap>
+            <v-flex xs12>
+              <v-card-actions class="px-0">
+                <v-btn small color="grey lighten-1" @click="initializeScreen()">
+                  表示を停止する
+                </v-btn>
+              </v-card-actions>
+            </v-flex>
+          </v-layout>
         </v-container>
       </v-card>
 
-      <v-card v-if="this.event">
+      <v-card v-if="this.selectedEvent">
         <v-list two-line>
 
-          <template v-for="presentation in event.presentations">
+          <template v-for="presentation in selectedEvent.presentations">
             <v-list-tile
               v-if="presentation.id"
-              @click="selectPresentation"
+              @click="selectPresentation(presentation)"
               :key="presentation.id + '_list'"
               class="my-2">
               <v-list-tile-avatar :key="presentation.id + '_avatar'">
-                <v-icon v-if="presentation.id == screen.displayPresentationId"
+                <v-icon v-if="presentation.id == screen.displayPresentationRef.id"
                   x-large
                   color="orange lighten-1">
                   cast_connected
@@ -65,7 +97,7 @@
             <v-divider :key="presentation.id + '_divider'" class="mx-2 my-2"></v-divider>
           </template>
 
-          <template v-if="event.presentations == 0">
+          <template v-if="selectedEvent.presentations == 0">
             <v-card-text>
               まだ発表はありません。
             </v-card-text>
@@ -88,8 +120,7 @@ export default {
   },
   data () {
     return {
-      selectedEventId: null,
-      event: null
+      selectedEvent: null
     }
   },
   computed: {
@@ -98,21 +129,37 @@ export default {
     },
     events () {
       return this.$store.getters.events
-    },
-    selectedEvent () {
-      return this.event
     }
   },
   methods: {
     setEventsPresentations (eventId) {
       if (!eventId) {
-        this.event = {}
+        this.selectedEvent = {}
       } else {
-        this.event = this.$store.getters.event(eventId)
+        this.selectedEvent = this.$store.getters.event(eventId)
       }
     },
-    selectPresentation () {
-      // TODO:表示中の発表をアップデート
+    selectPresentation (presentation) {
+      const msg = 'スクリーンの表示を「' +
+        presentation.title +
+        '」の情報に変更します。\n' +
+        'よろしいですか？'
+      if (confirm(msg)) {
+        // TODO:表示中の発表をアップデート
+      }
+    },
+    getEventTitle (eventId) {
+      const targetEvent = this.$store.getters.event(eventId)
+      if (targetEvent) {
+        return targetEvent.title
+      } else {
+        return ''
+      }
+    },
+    initializeScreen () {
+      if (confirm('スクリーンの表示をリセットします。よろしいですか？')) {
+        // TODO:スクリーンを初期化する処理を入れる
+      }
     }
   }
 }

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -9,7 +9,7 @@
             <div v-if="screen" class="grey--text">
               {{ screen.name }}
             </div>
-            <h3 class="headline mb-0">スクリーン管理</h3>
+            <h3 class="headline mb-0">スクリーンの管理</h3>
           </div>
         </v-card-title>
 

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -30,15 +30,13 @@
           </v-layout>
 
           <v-layout row wrap>
-            <v-flex xs12 sm3 xl1>
-              <v-card-title class="px-0 py-0">
-                <strong>表示中の発表：</strong>
-              </v-card-title>
-            </v-flex>
             <v-flex xs12 sm9 xl11>
 
               <template v-if="screen && screen.displayPresentationRef">
                 <v-card-title class="px-0 py-0" >
+                  <div>
+                    <strong>表示中の発表：</strong>
+                  </div>
                   <div class="text-truncate">
                     {{ getEventTitle(screen.displayPresentationRef.eventId) }}
                   </div>

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -171,7 +171,7 @@ export default {
         '」の情報に変更します。\n' +
         'よろしいですか？'
       if (confirm(msg)) {
-        this.$store.dispatch('updateScreen', {
+        this.$store.dispatch('updateScreenPresentation', {
           screenId: this.id,
           presentationId: targetPresentation.id
         })

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -53,12 +53,14 @@
                   cast
                 </v-icon>
               </v-list-item-avatar>
-              <v-list-tile-title class="title ml-2" :key="presentation.id + '_title'">
-                {{ presentation.title }}
-              </v-list-tile-title>
-              <v-list-tile-sub-title v-if="presentation.presenter" :key="presentation.id + '_subtitle'">
-                by {{ presentation.presenter.name }}
-              </v-list-tile-sub-title>
+              <v-list-tile-content class="ml-2">
+                <v-list-tile-title class="title" :key="presentation.id + '_title'">
+                  {{ presentation.title }}
+                </v-list-tile-title>
+                <v-list-tile-sub-title v-if="presentation.presenter" :key="presentation.id + '_subtitle'">
+                  by {{ presentation.presenter.name }}
+                </v-list-tile-sub-title>
+              </v-list-tile-content>
             </v-list-tile>
             <v-divider :key="presentation.id + '_divider'" class="mx-2 my-2"></v-divider>
           </template>

--- a/src/views/AdminScreenSetting.vue
+++ b/src/views/AdminScreenSetting.vue
@@ -155,7 +155,12 @@ export default {
         '」の情報に変更します。\n' +
         'よろしいですか？'
       if (confirm(msg)) {
-        // TODO:表示中の発表をアップデート
+        const screenInfo = this.$store.getters.screen(this.id)
+        this.$store.dispatch('updateScreen', {
+          screenId: this.id,
+          name: targetPresentation.name,
+          displayPresentationRef: targetPresentation.id
+        })
       }
     },
     /*

--- a/src/views/Error.vue
+++ b/src/views/Error.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <div>
+      <h1 class="headline mb-0">404エラー</h1>
+    </div>
+    <div>
+      お探しのコンテンツは存在しません。
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'error'
+}
+</script>

--- a/src/views/EventDetail.vue
+++ b/src/views/EventDetail.vue
@@ -41,7 +41,7 @@
 
       </v-card>
 
-      <v-card v-if :indeterminate="event.presentations == 0">
+      <v-card v-else :indeterminate="event.presentations == 0">
         <v-card-text>
           まだ発表はありません。
         </v-card-text>

--- a/src/views/EventDetail.vue
+++ b/src/views/EventDetail.vue
@@ -41,7 +41,7 @@
 
       </v-card>
 
-      <v-card v-else :indeterminate="event.presentations == 0">
+      <v-card v-if :indeterminate="event.presentations == 0">
         <v-card-text>
           まだ発表はありません。
         </v-card-text>

--- a/src/views/EventList.vue
+++ b/src/views/EventList.vue
@@ -44,6 +44,9 @@ import moment from 'moment'
 export default {
   name: 'events',
   computed: {
+    /*
+     * イベント一覧取得
+     */
     events () {
       const nowDate = new Date()
       return this.$store.getters.events


### PR DESCRIPTION
#76 がなぜかうまく差分表示されなかったのでプルリク作成しなおし。

サブスクリーンの管理画面を作成しました。
確認をお願いします。

---------------

サブスクリーンに表示するプレゼンを選択できるようにしました。
メニューからサブスクリーン画面へ遷移できますが、
管理ユーザのみにリンクが表示されるようになっています。
~~管理ユーザは、「permission」コレクションに、ユーザIDと `isAdmin = true` が登録されている必要があります。~~

追記
指摘により、管理者の管理方法を以下のように変更しました。

管理ユーザは、「permission」コレクションに、**ユーザIDとおなじIDのドキュメント内に、フィールド**、 `isAdmin = true` が登録されている必要があります。