### PR TITLE
Firebase SDKからの警告 Close #83

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script>
-import firebase from 'firebase'
+import firebase from 'firebase/app'
 import firebaseui from 'firebaseui-ja'
 import 'firebaseui-ja/dist/firebaseui.css'
 
@@ -19,7 +19,7 @@ export default {
     return {
       // FirebaseUIの設定値
       config: {
-        signInSuccessUrl: '/',
+        signInSuccessUrl: '/#/',
         signInOptions: [
           // 表示する認証バナーリスト
           firebase.auth.GithubAuthProvider.PROVIDER_ID


### PR DESCRIPTION
importにて警告が表示されていたので修正。

ついでにログイン成功時の遷移先を変更。
（`/` を指定していると、ページ全体の再読込みが走ってそうだったので。）

refs #83