### PR TITLE
バグ：ユーザ名が空欄になる

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -137,14 +137,15 @@ export default new Vuex.Store({
               })
           } else {
             // 未登録ユーザの場合
+            const registUserName = auth.displayName ? auth.displayName : auth.email.substr(0, auth.email.indexOf('@'))
             userDoc
               .set({
-                name: auth.displayName,
+                name: registUserName,
                 photoURL: auth.photoURL
               })
             commit('setUser', {
               id: auth.uid,
-              name: auth.displayName,
+              name: registUserName,
               photoURL: auth.photoURL,
               isAdmin: false
             })


### PR DESCRIPTION
# 概要
#99
ユーザ名がない場合、メールアドレスのアカウント名をユーザ名にするよう変更


# 補足

特になし

# マージしたときに閉じるIssue
* Close #99
