### PR TITLE
タップなしにコメントを入力

### DIFF
--- a/src/views/PresentationDetail.vue
+++ b/src/views/PresentationDetail.vue
@@ -187,6 +187,7 @@
               </ul>
             </v-alert>
             <v-textarea
+              v-if="dialog"
               outline
               autofocus
               no-resize


### PR DESCRIPTION
# 概要
コメント入力を開いたときに自動でテキストエリアにフォーカスが当たるようにした

# 補足
@skaji18 が[issueへのコメント](https://github.com/rodbb/lambic/issues/108#issuecomment-500124454)で教えてくれた方法を実装。共有感謝


# マージしたときに閉じるIssue
* Close #108