### PR TITLE
シャードの数変更

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
 VUE_APP_ISSUES_URL=https://github.com/rodbb/lambic/issues
-VUE_APP_STAMP_COUNT_SHARD_NUM=3
+VUE_APP_STAMP_COUNT_SHARD_NUM=1


### PR DESCRIPTION
# 概要
読み取り数削減の一環として、一旦スタンプカウントのシャード数を3から1へ変更。


# 補足
次回のイベントで様子を見る。

# マージしたときに閉じるIssue
なし
