### PR TITLE
スタンプカウントが4桁になると枠をはみ出して見えない

### DIFF
--- a/src/views/PresentationDetail.vue
+++ b/src/views/PresentationDetail.vue
@@ -69,10 +69,10 @@
             <v-avatar v-else color="grey lighten-3" class="black--text">
               {{ stamp.string }}
             </v-avatar>
-            <span v-if="getStampCount(stamp.id)">
+            <span v-if="getStampCount(stamp.id) || getStampCount(stamp.id)===0">
               {{ getStampCount(stamp.id) }}
             </span>
-            <span v-else :indeterminate="getStampCount(stamp.id) === null">
+            <span v-else>
               <v-progress-circular indeterminate
                 :size="15"
                 :width="2"
@@ -95,10 +95,10 @@
             <v-avatar v-else color="grey lighten-3" class="black--text">
               {{ stamp.string }}
             </v-avatar>
-            <span v-if="getStampCount(stamp.id)">
+            <span v-if="getStampCount(stamp.id) || getStampCount(stamp.id)===0">
               {{ getStampCount(stamp.id) }}
             </span>
-            <span v-else :indeterminate="getStampCount(stamp.id) === null">
+            <span v-else>
               <v-progress-circular indeterminate
                 :size="15"
                 :width="2"

--- a/src/views/PresentationDetail.vue
+++ b/src/views/PresentationDetail.vue
@@ -62,8 +62,9 @@
             color="light-green"
             text-color="white"
             class="text-xs-center"
+            label
           >
-            <v-avatar v-if="stamp.src" color="grey lighten-3">
+            <v-avatar v-if="stamp.src" tile color="grey lighten-3">
               <img :src="stamp.src">
             </v-avatar>
             <v-avatar v-else color="grey lighten-3" class="black--text">

--- a/src/views/PresentationDetail.vue
+++ b/src/views/PresentationDetail.vue
@@ -54,9 +54,8 @@
 
       <v-card  class="py-3 mb-2 sticky-top top-56">
         <template v-for="(stamp, index) in presentation.stamps">
-
           <v-chip
-            v-if="stamp.canUse !== false"
+            v-if="getStampCount(stamp.id) || getStampCount(stamp.id)===0"
             :key="index"
             @click="countUpStamp(stamp.id)"
             color="light-green"
@@ -70,45 +69,10 @@
             <v-avatar v-else color="grey lighten-3" class="black--text">
               {{ stamp.string }}
             </v-avatar>
-            <span v-if="getStampCount(stamp.id) || getStampCount(stamp.id)===0">
+            <span>
               {{ getStampCount(stamp.id) }}
             </span>
-            <span v-else>
-              <v-progress-circular indeterminate
-                :size="15"
-                :width="2"
-                color="grey lighten-2"
-              >
-              </v-progress-circular>
-            </span>
           </v-chip>
-
-          <v-chip
-            v-else
-            :key="index"
-            color="grey"
-            text-color="white"
-            class="text-xs-center"
-          >
-            <v-avatar v-if="stamp.src" color="grey lighten-3">
-              <img :src="stamp.src">
-            </v-avatar>
-            <v-avatar v-else color="grey lighten-3" class="black--text">
-              {{ stamp.string }}
-            </v-avatar>
-            <span v-if="getStampCount(stamp.id) || getStampCount(stamp.id)===0">
-              {{ getStampCount(stamp.id) }}
-            </span>
-            <span v-else>
-              <v-progress-circular indeterminate
-                :size="15"
-                :width="2"
-                color="grey lighten-2"
-              >
-              </v-progress-circular>
-            </span>
-          </v-chip>
-
         </template>
       </v-card>
 

--- a/src/views/PresentationDetail.vue
+++ b/src/views/PresentationDetail.vue
@@ -52,58 +52,62 @@
         </v-card-text>
       </v-card>
 
-      <v-card  class="pb-3 mb-2 sticky-top top-56">
+      <v-card  class="py-3 mb-2 sticky-top top-56">
         <template v-for="(stamp, index) in presentation.stamps">
-          <v-badge bottom overlap v-if="stamp.canUse !== false" :key="index">
-            <template v-slot:badge>
-              <span>{{ getStampCount(stamp.id) }}</span>
-            </template>
-            <v-card-actions :key="index">
-              <v-btn
-                v-if="stamp.src"
-                icon
-                @click="countUpStamp(stamp.id)"
+
+          <v-chip
+            v-if="stamp.canUse !== false"
+            :key="index"
+            @click="countUpStamp(stamp.id)"
+            color="light-green"
+            text-color="white"
+            class="text-xs-center"
+          >
+            <v-avatar v-if="stamp.src" color="grey lighten-3">
+              <img :src="stamp.src">
+            </v-avatar>
+            <v-avatar v-else color="grey lighten-3" class="black--text">
+              {{ stamp.string }}
+            </v-avatar>
+            <span v-if="getStampCount(stamp.id)">
+              {{ getStampCount(stamp.id) }}
+            </span>
+            <span v-else :indeterminate="getStampCount(stamp.id) === null">
+              <v-progress-circular indeterminate
+                :size="15"
+                :width="2"
+                color="grey lighten-2"
               >
-                <img
-                  class="stamp"
-                  :src="stamp.src"
-                >
-              </v-btn>
-              <v-btn
-                v-else
-                icon
-                :key="index"
-                @click="countUpStamp(stamp.id)"
+              </v-progress-circular>
+            </span>
+          </v-chip>
+
+          <v-chip
+            v-else
+            :key="index"
+            color="grey"
+            text-color="white"
+            class="text-xs-center"
+          >
+            <v-avatar v-if="stamp.src" color="grey lighten-3">
+              <img :src="stamp.src">
+            </v-avatar>
+            <v-avatar v-else color="grey lighten-3" class="black--text">
+              {{ stamp.string }}
+            </v-avatar>
+            <span v-if="getStampCount(stamp.id)">
+              {{ getStampCount(stamp.id) }}
+            </span>
+            <span v-else :indeterminate="getStampCount(stamp.id) === null">
+              <v-progress-circular indeterminate
+                :size="15"
+                :width="2"
+                color="grey lighten-2"
               >
-                {{ stamp.string }}
-              </v-btn>
-            </v-card-actions>
-          </v-badge>
-          <v-badge bottom overlap v-else color="grey" :key="index">
-            <template v-slot:badge>
-              <span>{{ getStampCount(stamp.id) }}</span>
-            </template>
-            <v-card-actions :key="index">
-              <v-btn
-                v-if="stamp.src"
-                icon
-                disabled
-               >
-                <img
-                  class="stamp"
-                  :src="stamp.src"
-                >
-              </v-btn>
-              <v-btn
-                v-else
-                icon
-                disabled
-                :key="index"
-              >
-                {{ stamp.string }}
-              </v-btn>
-            </v-card-actions>
-          </v-badge>
+              </v-progress-circular>
+            </span>
+          </v-chip>
+
         </template>
       </v-card>
 
@@ -355,12 +359,6 @@ export default {
 <style scoped>
 .pre {
   white-space: pre-wrap;
-}
-
-.stamp {
-  border-radius: 50%;
-  max-width: 28px;
-  max-height: 28px;
 }
 
 .sticky-top {

--- a/src/views/PresentationDetail.vue
+++ b/src/views/PresentationDetail.vue
@@ -55,7 +55,7 @@
       <v-card  class="py-3 mb-2 sticky-top top-56">
         <template v-for="(stamp, index) in presentation.stamps">
           <v-chip
-            v-if="getStampCount(stamp.id) || getStampCount(stamp.id)===0"
+            v-if="getStampCount(stamp.id) || getStampCount(stamp.id) === 0"
             :key="index"
             @click="countUpStamp(stamp.id)"
             color="light-green"


### PR DESCRIPTION
# 概要
こんな感じにしてみた。
これで3桁も4桁も大丈夫。

![image](https://user-images.githubusercontent.com/12679843/60750547-ca7c1480-9fe4-11e9-8025-07791b609871.png)



# 補足
既存の機能のデグレが発生していないか。

# マージしたときに閉じるIssue
* Close #124
