### PR TITLE
サブスクリーンへのQRコード表示

### DIFF
--- a/src/subscreen/main.js
+++ b/src/subscreen/main.js
@@ -4,6 +4,7 @@ import router from './router'
 import Vuetify from 'vuetify'
 import 'material-design-icons-iconfont/dist/material-design-icons.css'
 import 'vuetify/dist/vuetify.min.css'
+import VueQriously from 'vue-qriously'
 // import './registerServiceWorker'
 import firebase from 'firebase/app'
 import FirebaseConfig from '@/../firebase-config.json'
@@ -11,6 +12,7 @@ import FirebaseConfig from '@/../firebase-config.json'
 firebase.initializeApp(FirebaseConfig)
 
 Vue.use(Vuetify)
+Vue.use(VueQriously)
 Vue.config.productionTip = false
 
 new Vue({

--- a/src/subscreen/views/SubScreen.vue
+++ b/src/subscreen/views/SubScreen.vue
@@ -2,6 +2,8 @@
   <v-app>
     <v-toolbar height="80" extended>
       <v-toolbar-title class="display-3">{{ presentationTitle }}</v-toolbar-title>
+      <v-spacer></v-spacer>
+      <qriously id="qrcode" class="pt-1 pb-0" :value="qrUrl"/>
       <template v-slot:extension>
         <div class="display-2 text-truncate">{{ presenterName }}</div>
       </template>
@@ -85,6 +87,11 @@ export default {
       return (this.screenInfo !== null && this.screenInfo.name)
         ? this.screenInfo.name
         : '（名称未設定の会場）'
+    },
+    qrUrl () {
+      return (this.screenInfo !== null && this.screenInfo.displayPresentationRef !== null)
+        ? `${window.location.origin}/#/presentations/${this.screenInfo.displayPresentationRef.id}`
+        : window.location.origin
     }
   },
   watch: {
@@ -239,6 +246,9 @@ export default {
 </script>
 
 <style scoped>
+#qrcode {
+    height: 100%;
+}
 .blinking{
     animation:blink 0.2s ease-in-out infinite alternate;
 }

--- a/src/subscreen/views/SubScreen.vue
+++ b/src/subscreen/views/SubScreen.vue
@@ -3,7 +3,7 @@
     <v-toolbar height="80" extended>
       <v-toolbar-title class="display-3">{{ presentationTitle }}</v-toolbar-title>
       <v-spacer></v-spacer>
-      <qriously id="qrcode" class="pt-1 pb-0" :value="qrUrl" :size="140"/>
+      <qriously id="qrcode" class="pt-1 pb-0" :value="qrUrl" size="140"/>
       <template v-slot:extension>
         <div class="display-2 text-truncate">{{ presenterName }}</div>
       </template>

--- a/src/subscreen/views/SubScreen.vue
+++ b/src/subscreen/views/SubScreen.vue
@@ -3,7 +3,7 @@
     <v-toolbar height="80" extended>
       <v-toolbar-title class="display-3">{{ presentationTitle }}</v-toolbar-title>
       <v-spacer></v-spacer>
-      <qriously id="qrcode" class="pt-1 pb-0" :value="qrUrl"/>
+      <qriously id="qrcode" class="pt-1 pb-0" :value="qrUrl" :size="140"/>
       <template v-slot:extension>
         <div class="display-2 text-truncate">{{ presenterName }}</div>
       </template>


### PR DESCRIPTION
# 概要
#137
サブスクリーンにQRコードを表示することで、イベント開始前にLambicへのQRコード等をスクリーンに表示する手間が省ける。
（毎回QRコードが載ったスライドを表示しているが、地味に面倒。）

# 補足
## 仕様説明
![image](https://user-images.githubusercontent.com/12679843/62421494-911aef80-b6dd-11e9-81a6-5a0b3eb3e643.png)

サブスクリーンの右上（発表タイトル/発表者名の横）に、以下の情報のQRコードが表示されます。

* サブスクリーンに表示する発表が指定されているとき
  → その発表のURL
* サブスクリーンに表示する発表が指定されていないとき
  → LambicのTopページのURL

## 他注意点
サイズ指定の方法にもっといい方法があれば。

# マージしたときに閉じるIssue
* Close #137
